### PR TITLE
Feature/board

### DIFF
--- a/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
@@ -6,10 +6,8 @@ import com.passion.teampassiontrelloproject.board.service.BoardService;
 import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -21,6 +19,12 @@ public class BoardController {
     @PostMapping("/board")
     public BoardResponseDto createBoard(@RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return boardService.createBoard(boardRequestDto, userDetails.getUser());
+    }
+
+    @Transactional
+    @PutMapping("/board/{id}")
+    public BoardResponseDto updateBoard(@PathVariable Long id, @RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return boardService.updateBoard(id,boardRequestDto, userDetails.getUser());
     }
 
 

--- a/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
@@ -1,4 +1,28 @@
 package com.passion.teampassiontrelloproject.board.controller;
 
+import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
+import com.passion.teampassiontrelloproject.board.dto.BoardResponseDto;
+import com.passion.teampassiontrelloproject.board.service.BoardService;
+import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
 public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping("/board")
+    public BoardResponseDto createBoard(@RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return boardService.createBoard(boardRequestDto, userDetails.getUser());
+    }
+
+
+
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
@@ -3,8 +3,11 @@ package com.passion.teampassiontrelloproject.board.controller;
 import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
 import com.passion.teampassiontrelloproject.board.dto.BoardResponseDto;
 import com.passion.teampassiontrelloproject.board.service.BoardService;
+import com.passion.teampassiontrelloproject.common.dto.ApiResponseDto;
 import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -17,16 +20,21 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping("/board")
-    public BoardResponseDto createBoard(@RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+    public BoardResponseDto createBoard(@RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return boardService.createBoard(boardRequestDto, userDetails.getUser());
     }
 
     @Transactional
     @PutMapping("/board/{id}")
-    public BoardResponseDto updateBoard(@PathVariable Long id, @RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
-        return boardService.updateBoard(id,boardRequestDto, userDetails.getUser());
+    public BoardResponseDto updateBoard(@PathVariable Long id, @RequestBody BoardRequestDto boardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return boardService.updateBoard(id, boardRequestDto, userDetails.getUser());
     }
 
+    @DeleteMapping("/board/{id}")
+    public ResponseEntity<ApiResponseDto> deleteBoard(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        boardService.deleteBoard(id, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 완료!", HttpStatus.OK.value()));
+    }
 
 
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardRequestDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public class BoardRequestDto {
 
-    private String name;
     private String description;
     private String backgroundColor;
     private String title;

--- a/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardRequestDto.java
@@ -1,0 +1,12 @@
+package com.passion.teampassiontrelloproject.board.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BoardRequestDto {
+
+    private String name;
+    private String description;
+    private String backgroundColor;
+    private String title;
+}

--- a/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/dto/BoardResponseDto.java
@@ -1,0 +1,22 @@
+package com.passion.teampassiontrelloproject.board.dto;
+
+import com.passion.teampassiontrelloproject.board.entity.Board;
+import lombok.Getter;
+
+@Getter
+public class BoardResponseDto {
+
+    private Long id;
+    private String name;
+    private String description;
+    private String backgroundColor;
+    private String title;
+
+    public BoardResponseDto(Board board){
+        this.id = board.getId();
+        this.name = board.getName();
+        this.description = board.getDescription();
+        this.backgroundColor = board.getBackgroundColor();
+        this.title = board.getTitle();
+    }
+}

--- a/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
@@ -40,4 +40,12 @@ public class Board extends Timestamped {
         this.title = requestDto.getTitle();
     }
 
+    public void setUser(User user){
+        this.user = user;
+    }
+    public void update(BoardRequestDto boardRequestDto) {
+        this.backgroundColor = boardRequestDto.getBackgroundColor();
+        this.description = boardRequestDto.getDescription();
+        this.title = boardRequestDto.getTitle();
+    }
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
@@ -1,4 +1,43 @@
 package com.passion.teampassiontrelloproject.board.entity;
 
-public class Board {
+import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
+import com.passion.teampassiontrelloproject.common.entity.Timestamped;
+import com.passion.teampassiontrelloproject.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "Board")
+@NoArgsConstructor
+public class Board extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String backgroundColor;
+
+    @Column(nullable = false)
+    private String title;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user;
+
+    public Board(BoardRequestDto requestDto, User user) {
+        this.name = user.getUsername();
+        this.description = requestDto.getDescription();
+        this.backgroundColor = requestDto.getBackgroundColor();
+        this.title = requestDto.getTitle();
+    }
+
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/repository/BoardRepository.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/repository/BoardRepository.java
@@ -1,4 +1,9 @@
 package com.passion.teampassiontrelloproject.board.repository;
 
-public interface BoardRepository {
+import com.passion.teampassiontrelloproject.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board,Long> {
+
+
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
@@ -29,12 +29,19 @@ public class BoardService {
         Board board = boardRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 보드입니다."));
 
+        board.update(boardRequestDto);
+        return new BoardResponseDto(board);
+
+    }
+
+    public void deleteBoard(Long id, User user) {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 보드입니다."));
+
         if(!user.getId().equals(board.getUser().getId())){
             throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
         }
 
-        board.update(boardRequestDto);
-        return new BoardResponseDto(board);
-
+        boardRepository.delete(board);
     }
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
@@ -1,4 +1,24 @@
 package com.passion.teampassiontrelloproject.board.service;
 
+import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
+import com.passion.teampassiontrelloproject.board.dto.BoardResponseDto;
+import com.passion.teampassiontrelloproject.board.entity.Board;
+import com.passion.teampassiontrelloproject.board.repository.BoardRepository;
+import com.passion.teampassiontrelloproject.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public BoardResponseDto createBoard(BoardRequestDto boardRequestDto, User user) {
+        Board board = new Board(boardRequestDto,user);
+        boardRepository.save(board);
+        return new BoardResponseDto(board);
+    }
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
@@ -18,7 +18,23 @@ public class BoardService {
     @Transactional
     public BoardResponseDto createBoard(BoardRequestDto boardRequestDto, User user) {
         Board board = new Board(boardRequestDto,user);
+        board.setUser(user);
+
         boardRepository.save(board);
         return new BoardResponseDto(board);
+    }
+
+    @Transactional
+    public BoardResponseDto updateBoard(Long id,BoardRequestDto boardRequestDto, User user) {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 보드입니다."));
+
+        if(!user.getId().equals(board.getUser().getId())){
+            throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
+        }
+
+        board.update(boardRequestDto);
+        return new BoardResponseDto(board);
+
     }
 }


### PR DESCRIPTION
보드 기능 구현
- Board Entity common에 있는 Timestamped 상속받아 작성
-> 컬럼 중 name은 user 정보에서 받아옴
- 보드 생성 boardRequestDto와 user 데이터로 생성
-> 오류 있었으나 @Transactional 으로 해결

보드 수정 기능 구현
- Board에 update(이름, 색상, 설명) 만들어 수정
- name은 UserDetailsImpl에서 가쟈오기 떄문데 RequestDto에서 필드 삭제
- 생성시 userid가 들어가지 않아 setUser 추가
[featuer] 보드 삭제

보드 삭제 기능 구현
- 삭제 시 보드 삭제 완료 문구 반환
- user_id를 비교하여 작성자만 삭제 가능하도록 작성
- 수정에도 작성자를 비교하는 부분이 있었으나 삭제

