### PR TITLE
[fix-보드] 보드 수정, 삭제 api 개선

### DIFF
--- a/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
@@ -32,8 +32,7 @@ public class BoardController {
 
     @DeleteMapping("/board/{id}")
     public ResponseEntity<ApiResponseDto> deleteBoard(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        boardService.deleteBoard(id, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 완료!", HttpStatus.OK.value()));
+        return boardService.deleteBoard(id, userDetails.getUser());
     }
 
 

--- a/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
@@ -4,8 +4,11 @@ import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
 import com.passion.teampassiontrelloproject.board.dto.BoardResponseDto;
 import com.passion.teampassiontrelloproject.board.entity.Board;
 import com.passion.teampassiontrelloproject.board.repository.BoardRepository;
+import com.passion.teampassiontrelloproject.common.dto.ApiResponseDto;
 import com.passion.teampassiontrelloproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,22 +29,24 @@ public class BoardService {
 
     @Transactional
     public BoardResponseDto updateBoard(Long id,BoardRequestDto boardRequestDto, User user) {
-        Board board = boardRepository.findById(id).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않는 보드입니다."));
+        Board board = findBoard(id);
 
         board.update(boardRequestDto);
         return new BoardResponseDto(board);
 
     }
 
-    public void deleteBoard(Long id, User user) {
-        Board board = boardRepository.findById(id).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않는 보드입니다."));
-
+    public ResponseEntity<ApiResponseDto> deleteBoard(Long id, User user) {
+        Board board = findBoard(id);
         if(!user.getId().equals(board.getUser().getId())){
             throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
         }
 
         boardRepository.delete(board);
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 완료!", HttpStatus.OK.value()));
+    }
+
+    public Board findBoard(Long id){
+        return boardRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 보드입니다."));
     }
 }


### PR DESCRIPTION
보드 수정, 삭제 api 개선
- deleteBoard 삭제 시 문구 반환 service로 이동
- 수정, 삭제의 findById를 findBoard 메서드로 만들어 사용