### PR TITLE
Feature/board invite

### DIFF
--- a/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/controller/BoardController.java
@@ -5,8 +5,8 @@ import com.passion.teampassiontrelloproject.board.dto.BoardResponseDto;
 import com.passion.teampassiontrelloproject.board.service.BoardService;
 import com.passion.teampassiontrelloproject.common.dto.ApiResponseDto;
 import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
+import com.passion.teampassiontrelloproject.userBoard.dto.UserBoardRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +33,11 @@ public class BoardController {
     @DeleteMapping("/board/{id}")
     public ResponseEntity<ApiResponseDto> deleteBoard(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return boardService.deleteBoard(id, userDetails.getUser());
+    }
+
+    @PostMapping("/board/invite")
+    public ResponseEntity<ApiResponseDto> inviteBoard(@RequestBody UserBoardRequestDto userBoardRequestDto){
+        return boardService.inviteBoard(userBoardRequestDto);
     }
 
 

--- a/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/entity/Board.java
@@ -3,9 +3,13 @@ package com.passion.teampassiontrelloproject.board.entity;
 import com.passion.teampassiontrelloproject.board.dto.BoardRequestDto;
 import com.passion.teampassiontrelloproject.common.entity.Timestamped;
 import com.passion.teampassiontrelloproject.user.entity.User;
+import com.passion.teampassiontrelloproject.userBoard.entity.UserBoard;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -32,6 +36,9 @@ public class Board extends Timestamped {
     @ManyToOne
     @JoinColumn(name="user_id")
     private User user;
+
+    @OneToMany(mappedBy = "board")
+    private List<UserBoard> UserBoards = new ArrayList<>();
 
     public Board(BoardRequestDto requestDto, User user) {
         this.name = user.getUsername();

--- a/src/main/java/com/passion/teampassiontrelloproject/board/repository/BoardRepository.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/repository/BoardRepository.java
@@ -3,7 +3,10 @@ package com.passion.teampassiontrelloproject.board.repository;
 import com.passion.teampassiontrelloproject.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardRepository extends JpaRepository<Board,Long> {
 
+    Optional<Board> findByTitle(String title);
 
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/board/service/BoardService.java
@@ -6,6 +6,10 @@ import com.passion.teampassiontrelloproject.board.entity.Board;
 import com.passion.teampassiontrelloproject.board.repository.BoardRepository;
 import com.passion.teampassiontrelloproject.common.dto.ApiResponseDto;
 import com.passion.teampassiontrelloproject.user.entity.User;
+import com.passion.teampassiontrelloproject.user.repository.UserRepository;
+import com.passion.teampassiontrelloproject.userBoard.dto.UserBoardRequestDto;
+import com.passion.teampassiontrelloproject.userBoard.entity.UserBoard;
+import com.passion.teampassiontrelloproject.userBoard.repository.UserBoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final UserBoardRepository userBoardRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public BoardResponseDto createBoard(BoardRequestDto boardRequestDto, User user) {
-        Board board = new Board(boardRequestDto,user);
+        Board board = new Board(boardRequestDto, user);
         board.setUser(user);
 
         boardRepository.save(board);
@@ -28,17 +34,19 @@ public class BoardService {
     }
 
     @Transactional
-    public BoardResponseDto updateBoard(Long id,BoardRequestDto boardRequestDto, User user) {
+    public BoardResponseDto updateBoard(Long id, BoardRequestDto boardRequestDto, User user) {
         Board board = findBoard(id);
+        findUser(user);
 
         board.update(boardRequestDto);
         return new BoardResponseDto(board);
-
     }
 
     public ResponseEntity<ApiResponseDto> deleteBoard(Long id, User user) {
         Board board = findBoard(id);
-        if(!user.getId().equals(board.getUser().getId())){
+        findUser(user);
+
+        if (!user.getId().equals(board.getUser().getId())) {
             throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
         }
 
@@ -46,7 +54,23 @@ public class BoardService {
         return ResponseEntity.ok().body(new ApiResponseDto("보드 삭제 완료!", HttpStatus.OK.value()));
     }
 
-    public Board findBoard(Long id){
+
+    public ResponseEntity<ApiResponseDto> inviteBoard(UserBoardRequestDto userBoardRequestDto) {
+        User user = userRepository.findByUsername(userBoardRequestDto.getInviteUsername()).orElseThrow(
+                ()-> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Board board = boardRepository.findByTitle(userBoardRequestDto.getInviteBoardTitle()).orElseThrow(
+                ()-> new IllegalArgumentException("존재하지 않는 보드입니다."));
+
+        UserBoard userBoard = new UserBoard(user, board, userBoardRequestDto);
+        userBoardRepository.save(userBoard);
+        return ResponseEntity.ok().body(new ApiResponseDto("보드 초대 완료!",HttpStatus.CREATED.value()));
+    }
+
+    public Board findBoard(Long id) {
         return boardRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 보드입니다."));
+    }
+
+    public UserBoard findUser(User user){
+        return userBoardRepository.findByUser(user).orElseThrow(() -> new IllegalArgumentException("초대받지 못한 보드입니다."));
     }
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/user/entity/User.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.passion.teampassiontrelloproject.user.entity;
 
 import com.passion.teampassiontrelloproject.common.entity.Timestamped;
+import com.passion.teampassiontrelloproject.userBoard.entity.UserBoard;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,8 @@ public class User extends Timestamped {
 
     private boolean isBlocked = false;
 
+    @OneToMany(mappedBy = "user")
+    private List<UserBoard> UserBoards = new ArrayList<>();
 
     public User(String username, String password, String email, UserRoleEnum role) {
         this.username = username;

--- a/src/main/java/com/passion/teampassiontrelloproject/userBoard/dto/UserBoardRequestDto.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/userBoard/dto/UserBoardRequestDto.java
@@ -1,0 +1,10 @@
+package com.passion.teampassiontrelloproject.userBoard.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserBoardRequestDto {
+
+    private String inviteUsername;
+    private String inviteBoardTitle;
+}

--- a/src/main/java/com/passion/teampassiontrelloproject/userBoard/entity/UserBoard.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/userBoard/entity/UserBoard.java
@@ -1,0 +1,38 @@
+package com.passion.teampassiontrelloproject.userBoard.entity;
+
+import com.passion.teampassiontrelloproject.board.entity.Board;
+import com.passion.teampassiontrelloproject.user.entity.User;
+import com.passion.teampassiontrelloproject.userBoard.dto.UserBoardRequestDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserBoard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String inviteUsername;
+    private String inviteBoardTitle;
+
+    @ManyToOne
+    @JoinColumn(name ="user_id" )
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name="board_id")
+    private Board board;
+
+    public UserBoard(User user, Board board, UserBoardRequestDto userBoardRequestDto){
+        this.user = user;
+        this.board = board;
+        this.inviteUsername = userBoardRequestDto.getInviteUsername();
+        this.inviteBoardTitle = userBoardRequestDto.getInviteBoardTitle();
+    }
+
+
+
+}

--- a/src/main/java/com/passion/teampassiontrelloproject/userBoard/repository/UserBoardRepository.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/userBoard/repository/UserBoardRepository.java
@@ -1,0 +1,11 @@
+package com.passion.teampassiontrelloproject.userBoard.repository;
+
+import com.passion.teampassiontrelloproject.user.entity.User;
+import com.passion.teampassiontrelloproject.userBoard.entity.UserBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserBoardRepository extends JpaRepository<UserBoard,Long > {
+    Optional<UserBoard> findByUser(User user);
+}


### PR DESCRIPTION
UserBoard 생성
- 연관 관계 id와 username, boardTitle을 가진 테이블 생성
- 요청 값 : username, boardTitle

연관관계 기능 구현
- UserBoard : user, board => N: 1 연관 관계 설정

보드 초대 기능 구현
- username, boardTitle을 통해 user, board 생성
-> findByUsername, findByTitle 각 repository에 생성
-> 찾을 수 없는 경우 Exception
- 초대 성공시 "보드 초대 완료"  응답
- 수정, 삭제에 userBoard 확인용 메서드 추가(findUser)