### PR TITLE
Feature/aop

### DIFF
--- a/src/main/java/com/passion/teampassiontrelloproject/aop/BoardInviteAop.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/aop/BoardInviteAop.java
@@ -1,5 +1,7 @@
 package com.passion.teampassiontrelloproject.aop;
 
+import com.passion.teampassiontrelloproject.column.dto.ColumnsRequestDto;
+import com.passion.teampassiontrelloproject.column.entity.Columns;
 import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
 import com.passion.teampassiontrelloproject.user.entity.User;
 import com.passion.teampassiontrelloproject.userBoard.repository.UserBoardRepository;
@@ -24,19 +26,58 @@ public class BoardInviteAop {
     @Pointcut("execution(* com.passion.teampassiontrelloproject.card.service.CardService.*(..))")
     private void cardService() {}
 
+    @Pointcut("execution(* com.passion.teampassiontrelloproject.column.service.ColumnsService.createColumns(..))")
+    private void createColumns() {}
+
+    @Pointcut("execution(* com.passion.teampassiontrelloproject.column.service.ColumnsService.updateColumns(..))")
+    private void updateColumns() {}
+
+    @Pointcut("execution(* com.passion.teampassiontrelloproject.column.service.ColumnsService.deleteColumns(..))")
+    private void deleteColumns() {}
+
+    @Pointcut("execution(* com.passion.teampassiontrelloproject.board.service.BoardService.*(..))")
+    private void boardService() {}
+
     @Around("cardService()")
-    public Object executeAuthority(ProceedingJoinPoint joinPoint) throws Throwable{
-        Long boardId = (Long)joinPoint.getArgs()[1];
+    public Object executeAuthorityCard(ProceedingJoinPoint joinPoint) throws Throwable{
+        Long cardBoardId = (Long)joinPoint.getArgs()[1];
 
         // user
+        userCheck(cardBoardId);
+        return joinPoint.proceed();
+    }
+
+    @Around("createColumns() || updateColumns()")
+    public Object executeAuthorityColumns(ProceedingJoinPoint joinPoint) throws Throwable{
+        ColumnsRequestDto columnsRequestDto = (ColumnsRequestDto) joinPoint.getArgs()[0];
+        Long columnsBoardId = columnsRequestDto.getBoardId();
+
+        // user
+        userCheck(columnsBoardId);
+        return joinPoint.proceed();
+    }
+
+    @Around("deleteColumns()")
+    public Object executeAuthorityColumnsDelete(ProceedingJoinPoint joinPoint) throws Throwable{
+        Columns Columns = (Columns) joinPoint.getArgs()[0];
+        Long columnsBoardId = Columns.getBoard().getId();
+
+        // user
+        userCheck(columnsBoardId);
+        return joinPoint.proceed();
+    }
+
+
+
+    public void userCheck(Long id){
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if(auth != null && auth.getPrincipal().getClass() == UserDetailsImpl.class){
             UserDetailsImpl userDetails = (UserDetailsImpl) auth.getPrincipal();
             User user = userDetails.getUser();
 
-            userBoardRepository.findByUserIdAndBoardId(user.getId(), boardId).orElseThrow(() ->
+            userBoardRepository.findByUserIdAndBoardId(user.getId(), id).orElseThrow(() ->
                     new IllegalArgumentException("보드에 속한 유저가 아닙니다."));
         }
-        return joinPoint.proceed();
     }
+
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/aop/BoardInviteAop.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/aop/BoardInviteAop.java
@@ -1,0 +1,42 @@
+package com.passion.teampassiontrelloproject.aop;
+
+import com.passion.teampassiontrelloproject.common.security.UserDetailsImpl;
+import com.passion.teampassiontrelloproject.user.entity.User;
+import com.passion.teampassiontrelloproject.userBoard.repository.UserBoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "BoardInviteAop")
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class BoardInviteAop {
+
+    private final UserBoardRepository userBoardRepository;
+
+    @Pointcut("execution(* com.passion.teampassiontrelloproject.card.service.CardService.*(..))")
+    private void cardService() {}
+
+    @Around("cardService()")
+    public Object executeAuthority(ProceedingJoinPoint joinPoint) throws Throwable{
+        Long boardId = (Long)joinPoint.getArgs()[1];
+
+        // user
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if(auth != null && auth.getPrincipal().getClass() == UserDetailsImpl.class){
+            UserDetailsImpl userDetails = (UserDetailsImpl) auth.getPrincipal();
+            User user = userDetails.getUser();
+
+            userBoardRepository.findByUserIdAndBoardId(user.getId(), boardId).orElseThrow(() ->
+                    new IllegalArgumentException("보드에 속한 유저가 아닙니다."));
+        }
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/passion/teampassiontrelloproject/card/controller/CardController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/card/controller/CardController.java
@@ -43,7 +43,7 @@ public class CardController {
     // 카드 수정
     @PutMapping("/{cardId}")
     public ResponseEntity<CardResponseDto> updateCard(@PathVariable Long cardId, @RequestBody CardRequestDto cardRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        CardResponseDto updateCard = cardService.updateCard(cardRequestDto, userDetails.getUser(), cardRequestDto.getBoardId(), cardId);
+        CardResponseDto updateCard = cardService.updateCard(cardRequestDto, cardRequestDto.getBoardId(), userDetails.getUser(), cardId);
         if (updateCard != null) {
             return new ResponseEntity<>(updateCard, HttpStatus.OK);
         } else {
@@ -61,7 +61,7 @@ public class CardController {
     // 작업자 할당
     @PostMapping("/collaborator")
     public ResponseEntity<ApiResponseDto> collaborator(@RequestBody CardCollaboratorsRequestDto cardCollaboratorsRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return cardService.collaborator(cardCollaboratorsRequestDto, userDetails.getUser(), cardCollaboratorsRequestDto.getBoardId());
+        return cardService.collaborator(cardCollaboratorsRequestDto, cardCollaboratorsRequestDto.getBoardId(), userDetails.getUser());
     }
 
     // 할당 된 유저 조회

--- a/src/main/java/com/passion/teampassiontrelloproject/card/service/CardService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/card/service/CardService.java
@@ -2,13 +2,17 @@ package com.passion.teampassiontrelloproject.card.service;
 
 import com.passion.teampassiontrelloproject.card.dto.CardRequestDto;
 import com.passion.teampassiontrelloproject.card.dto.CardResponseDto;
+import com.passion.teampassiontrelloproject.cardCollaborators.dto.CardCollaboratorsRequestDto;
+import com.passion.teampassiontrelloproject.common.dto.ApiResponseDto;
 import com.passion.teampassiontrelloproject.user.entity.User;
+import org.springframework.http.ResponseEntity;
 
 public interface CardService {
-    CardResponseDto getCardById(Long id);
+//    CardResponseDto getCardById(Long id);
     CardResponseDto createdCard(CardRequestDto cardRequestDto, Long boardId, Long columnId, User user);
-    CardResponseDto updateCard(CardRequestDto cardRequestDto, User user, Long boardId, Long cardId);
+    CardResponseDto updateCard(CardRequestDto cardRequestDto, Long boardId, User user, Long cardId);
     void deleteCard(User user, Long boardId, Long cardId);
 
-    CardResponseDto updateDueDate (Long cardId, Long boardId, String dueDate, User user);
+    CardResponseDto updateDueDate (Long cardId, Long boardId, String dueDate, User user); // *
+    ResponseEntity<ApiResponseDto> collaborator(CardCollaboratorsRequestDto cardCollaboratorsRequestDto, Long boardId, User user);
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/card/service/CardServiceImpl.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/card/service/CardServiceImpl.java
@@ -36,7 +36,6 @@ public class CardServiceImpl implements CardService {
     private final ColumnsRepository columnsRepository;
 
     @Transactional
-    @Override
     public CardResponseDto getCardById(Long id) {
         Card card = findCard(id);
         return new CardResponseDto(card);
@@ -45,7 +44,7 @@ public class CardServiceImpl implements CardService {
     @Transactional
     @Override
     public CardResponseDto createdCard(CardRequestDto cardRequestDto, Long boardId, Long columnId, User user) {
-        authority(user, boardId);
+//        authority(user, boardId);
         Columns columns = columnsRepository.findById(columnId)
                 .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 컬럼입니다."));
         Card card = new Card(cardRequestDto, user, columns);
@@ -59,8 +58,8 @@ public class CardServiceImpl implements CardService {
 
     @Transactional
     @Override
-    public CardResponseDto updateCard(CardRequestDto cardRequestDto, User user, Long boardId, Long cardId) {
-        authority(user, boardId);
+    public CardResponseDto updateCard(CardRequestDto cardRequestDto, Long boardId, User user, Long cardId) {
+//        authority(user, boardId);
         Card card = findCard(cardId);
         checkCollaborators(card, user);
         card.update(cardRequestDto);
@@ -70,7 +69,7 @@ public class CardServiceImpl implements CardService {
     @Transactional
     @Override
     public void deleteCard(User user, Long boardId, Long cardId) {
-        authority(user, boardId);
+//        authority(user, boardId);
         Card card = findCard(cardId);
         checkCollaborators(card, user);
         cardRepository.delete(card);
@@ -79,8 +78,8 @@ public class CardServiceImpl implements CardService {
 
     // 카드에 유저 할당
     @Transactional
-    public ResponseEntity<ApiResponseDto> collaborator(CardCollaboratorsRequestDto cardCollaboratorsRequestDto, User user, Long boardId) {
-        authority(user, boardId);
+    public ResponseEntity<ApiResponseDto> collaborator(CardCollaboratorsRequestDto cardCollaboratorsRequestDto, Long boardId, User user) {
+//        authority(user, boardId);
         // 할당 할 유저 조회
         User collaborator = findUser(user, cardCollaboratorsRequestDto.getUsername(), boardId);
 
@@ -115,7 +114,7 @@ public class CardServiceImpl implements CardService {
     @Override
     public CardResponseDto updateDueDate(Long cardId, Long boardId, String dueDate, User user) throws DateTimeParseException {
         // 보드 유저인지 확인
-        authority(user, boardId);
+//        authority(user, boardId);
 
         // 카드 조회
         Card card = findCard(cardId);
@@ -143,17 +142,17 @@ public class CardServiceImpl implements CardService {
     }
 
     // 보드에 속한 유저가 아니라면 카드에 대한 권한을 가질 수 없음
-    public void authority(User user, Long boardId) {
-        userBoardRepository.findByUserIdAndBoardId(user.getId(), boardId).orElseThrow(() ->
-                new IllegalArgumentException("보드에 속한 유저가 아닙니다."));
-    }
+//    public void authority(User user, Long boardId) {
+//        userBoardRepository.findByUserIdAndBoardId(user.getId(), boardId).orElseThrow(() ->
+//                new IllegalArgumentException("보드에 속한 유저가 아닙니다."));
+//    }
 
     // 유저 조회
     public User findUser(User user, String username, Long boardId) {
         User user1 = userRepository.findByUsernameAndIsDeletedFalse(username).orElseThrow(()->
                 new IllegalArgumentException("존재하지 않는 유저입니다"));
 
-        authority(user1, boardId);
+//        authority(user1, boardId);
         if (user.getUsername().equals(username)) {
             throw new IllegalArgumentException("본인은 할당 할 수 없습니다");
         }

--- a/src/main/java/com/passion/teampassiontrelloproject/column/controller/ColumnController.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/column/controller/ColumnController.java
@@ -30,24 +30,24 @@ public class ColumnController {
     @PutMapping("/columns/{id}")
     public ResponseEntity<ApiResponseDto> updateColumns(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id, @RequestBody ColumnsRequestDto requestDto) {
         Columns columns = columnsService.findColumns(id);
+        ColumnsResponseDto result = columnsService.updateColumns(requestDto,columns,  userDetails.getUser());
 
         if (!columns.getUser().getId().equals(userDetails.getUser().getId())) {
             throw new IllegalArgumentException("작성자만 수정 할 수 있습니다.");
         }
 
-        ColumnsResponseDto result = columnsService.updateColumns(columns, requestDto, userDetails.getUser());
         return ResponseEntity.ok().body(result);
     }
 
     @DeleteMapping("/columns/{id}")
     public ResponseEntity<ApiResponseDto> deleteColumns(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
         Columns columns = columnsService.findColumns(id);
+        columnsService.deleteColumns(columns, userDetails.getUser());
 
         if (!columns.getUser().getId().equals(userDetails.getUser().getId())) {
             throw new IllegalArgumentException("작성자만 삭제 할 수 있습니다.");
         }
 
-        columnsService.deleteColumns(columns, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto("컬럼 삭제 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/passion/teampassiontrelloproject/column/service/ColumnsService.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/column/service/ColumnsService.java
@@ -17,7 +17,7 @@ public interface ColumnsService {
     Columns findColumns(long id);
 
     @Transactional
-    ColumnsResponseDto updateColumns(Columns columns, ColumnsRequestDto requestDto, User user);
+    ColumnsResponseDto updateColumns(ColumnsRequestDto requestDto, Columns columns, User user);
 
 }
 

--- a/src/main/java/com/passion/teampassiontrelloproject/column/service/ColumnsServiceImpl.java
+++ b/src/main/java/com/passion/teampassiontrelloproject/column/service/ColumnsServiceImpl.java
@@ -39,7 +39,7 @@ public class ColumnsServiceImpl implements ColumnsService {
 
     @Override
     @Transactional
-    public ColumnsResponseDto updateColumns(Columns columns, ColumnsRequestDto requestDto, User user) {
+    public ColumnsResponseDto updateColumns(ColumnsRequestDto requestDto,Columns columns,  User user) {
 
         columns.setTitle(requestDto.getTitle());
         columns.setName(requestDto.getName());


### PR DESCRIPTION
[featuer] aop 생성_Card

- cardService 전체 메서드에 적용되는 aop 생성
-> 두번째 매개변수의 값을 boardId로 가져와서 User와 같이 DB에서 확인
- boardId를 두번째로 받도록 수정
- authority 적용되지 않는 getCardById 주석 처리
- authority 적용되야하는 collaborator 추가
- authority 전체 주석 처리

[featuer] aop 생성_Columns

- aop 의 user 확인 부분 중복되어 userCheck 로 분리
- Columns 생성, 수정, 삭제 aop에 추가
-> requestDto, Columns에 있는 boardId를 통해 확인
- ColumnController if문 위치 변경
-> 작성자 체크 후 보드 초대 여부를 확인하여 위치 조정
- 매개변수 순서 변경
-> aop에서 매개변수에 위치를 가져오기 때문에 순서를 바꿈